### PR TITLE
feat: 공용 둥근 버튼 컴포넌트 & 로그인/회원가입 페이지 퍼블리싱

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,14 +11,14 @@ import Contact from './pages/Contact';
 function App() {
   return (
     <>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/mypage" element={<MyPage />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/signupselect/:type" element={<SignUpSelect />} />
-        <Route path="/signup/:type/:target" element={<SignUp />} />
-        <Route path="/contact/:id" element={<Contact />} />
-      </Routes>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/mypage" element={<MyPage />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/signupselect/:type" element={<SignUpSelect />} />
+          <Route path="/signup/:type/:target" element={<SignUp />} />
+          <Route path="/contact/:id" element={<Contact />} />
+        </Routes>
     </>
   );
 }

--- a/src/api/http.js
+++ b/src/api/http.js
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+export const http = axios.create({
+  baseURL: import.meta.env.VITE_REACT_APP_API_URL,
+  withCredentials: true,
+});
+
+const token = window.localStorage.getItem('accessToken') ?? false;
+
+http.defaults.headers.common['Authorization'] = token
+  ? `Bearer ${token}`
+  : null;

--- a/src/api/user.js
+++ b/src/api/user.js
@@ -1,0 +1,17 @@
+import { http } from './http';
+
+const REDIRECT_URI = 'https://sweetme.vercel.app/oauth/kakao/callback';
+const CLIENT_ID = `${import.meta.env.VITE_REACT_APP_KAKAO_REST_API_KEY}`;
+
+export const KAKAO_AUTH_URI = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}`;
+
+export const sendCode = async (code) => {
+  try {
+    const res = await http.post('/kakao/login', {
+      code,
+    });
+    return res;
+  } catch (err) {
+    console.log(err);
+  }
+};

--- a/src/components/_common/Required.jsx
+++ b/src/components/_common/Required.jsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+const Required = () => {
+  return <Mark>*</Mark>;
+};
+
+export default Required;
+
+const Mark = styled.span`
+  font-size: 20px;
+  font-weight: bold;
+  color: var(--red);
+  margin-left: 3px;
+
+  position: relative;
+  top: 3px;
+`;

--- a/src/components/_common/RoundButton.jsx
+++ b/src/components/_common/RoundButton.jsx
@@ -1,0 +1,30 @@
+import styled from 'styled-components';
+
+const RoundButton = ({ text, color, mt, onClick }) => {
+  return (
+    <Button onClick={onClick} className={color} mt={mt}>
+      {text}
+    </Button>
+  );
+};
+
+export default RoundButton;
+
+const Button = styled.button`
+  height: 45px;
+  width: 100%;
+  font-size: 16px;
+  border-radius: 30px;
+  box-shadow: var(--shadow);
+  align-items: center;
+  margin-top: ${(prop) => prop.mt || 0}px;
+  cursor: pointer;
+
+  &.green {
+    background-color: var(--green);
+  }
+
+  &.blue {
+    background-color: var(--blue);
+  }
+`;

--- a/src/components/signup/AdressInput.jsx
+++ b/src/components/signup/AdressInput.jsx
@@ -1,0 +1,124 @@
+import DaumPostcode from 'react-daum-postcode';
+import styled from 'styled-components';
+import { useState } from 'react';
+
+import Required from '../_common/Required';
+
+const AddressInput = () => {
+  const [zonecode, setZonecode] = useState('');
+  const [address, setAddress] = useState('');
+  const [detailedAddress, setDetailedAddress] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+
+  const themeObj = {
+    bgColor: '#FFFFFF',
+    pageBgColor: '#FFFFFF',
+    postcodeTextColor: '#C05850',
+    emphTextColor: '#222222',
+  };
+
+  const postCodeStyle = {
+    width: '360px',
+    height: '480px',
+  };
+
+  const toggleHandler = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  const handleComplete = (data) => {
+    const { address, zonecode } = data;
+    setZonecode(zonecode);
+    setAddress(address);
+  };
+
+  const closeHandler = (state) => {
+    if (state === 'FORCE_CLOSE') {
+      setIsOpen(false);
+    } else if (state === 'COMPLETE_CLOSE') {
+      setIsOpen(false);
+    }
+  };
+
+  const onInputChange = (e) => {
+    setDetailedAddress(e.target.value);
+  };
+
+  return (
+    <Container>
+      <Wrapper>
+        <div>
+          <label htmlFor="address">
+            주소
+            <Required />
+          </label>
+          <ZoneCodeWrapper>
+            <Input className="zoneCode" type="text" value={zonecode} />
+            <button type="button" onClick={toggleHandler}>
+              우편번호 찾기
+            </button>
+          </ZoneCodeWrapper>
+        </div>
+        <Input className="address" type="text" value={address} />
+        <Input
+          className="detailedAddress"
+          type="text"
+          value={detailedAddress}
+          onChange={onInputChange}
+          placeholder="상세주소를 입력해주세요"
+        />
+      </Wrapper>
+      {isOpen && (
+        <div>
+          <DaumPostcode
+            theme={themeObj}
+            style={postCodeStyle}
+            onComplete={handleComplete}
+            onClose={closeHandler}
+          />
+        </div>
+      )}
+    </Container>
+  );
+};
+
+export default AddressInput;
+
+const Container = styled.div`
+  margin-bottom: 8px;
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  label {
+    font-size: 16px;
+  }
+`;
+
+const ZoneCodeWrapper = styled.div`
+  display: flex;
+  gap: 8px;
+
+  button {
+    background-color: var(--green);
+    box-shadow: var(--shadow);
+    border-radius: 5px;
+    font-size: 14px;
+    flex: 0.6;
+  }
+`;
+
+const Input = styled.input`
+  height: 40px;
+  border: 1px solid #909090;
+  border-radius: 5px;
+  padding: 10px 15px;
+  font-size: 14px;
+
+  &.zoneCode {
+    flex: 0.4;
+  }
+`;

--- a/src/components/signup/Alert.jsx
+++ b/src/components/signup/Alert.jsx
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+const Alert = ({ text }) => {
+  return <P>{text}</P>;
+};
+
+export default Alert;
+
+const P = styled.p`
+  color: var(--red);
+  font-size: 12px;
+  font-weight: bold;
+`;

--- a/src/components/signup/Center.jsx
+++ b/src/components/signup/Center.jsx
@@ -1,0 +1,116 @@
+import styled from 'styled-components';
+import { useState } from 'react';
+
+const Center = () => {
+  const [carYn, setCarYn] = useState(false);
+
+  return (
+    <Container>
+      <Wrapper>
+        <CarYn>
+          <Label className="car">목욕 차량 소유 여부</Label>
+          <RadioWrapper>
+            <div>
+              <label htmlFor="yes">예</label>
+              <input
+                type="radio"
+                name="carYn"
+                value="true"
+                id="yes"
+                checked={carYn}
+                onChange={() => setCarYn(true)}
+              />
+            </div>
+            <div>
+              <label htmlFor="no">아니오</label>
+              <input
+                type="radio"
+                name="carYn"
+                value="false"
+                id="no"
+                checked={!carYn}
+                onChange={() => setCarYn(false)}
+              />
+            </div>
+          </RadioWrapper>
+        </CarYn>
+      </Wrapper>
+      <Wrapper>
+        <CenterGrade>
+          <Label htmlFor="grade">센터 등급(선택)</Label>
+          <Input
+            type="text"
+            id="grade"
+            placeholder="센터 등급을 입력하세요."
+            maxLength="20"
+          />
+        </CenterGrade>
+        <CenterPeriod>
+          <Label htmlFor="period">운영 기간(선택)</Label>
+          <Input
+            type="text"
+            id="period"
+            placeholder="운영 기간을 입력하세요."
+            maxLength="20"
+          />
+        </CenterPeriod>
+      </Wrapper>
+    </Container>
+  );
+};
+
+export default Center;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;
+
+const Wrapper = styled.div``;
+
+const CarYn = styled.section`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const Label = styled.label`
+  font-size: 16px;
+
+  &.car {
+    font-weight: bold;
+  }
+`;
+
+const Input = styled.input`
+  height: 40px;
+  border: 1px solid #909090;
+  border-radius: 5px;
+  padding: 10px 15px;
+  font-size: 14px;
+`;
+
+const RadioWrapper = styled.div`
+  display: flex;
+
+  input {
+    margin-left: 5px;
+  }
+
+  div:first-child {
+    margin-right: 24px;
+  }
+`;
+
+const CenterGrade = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin-bottom: 8px;
+`;
+
+const CenterPeriod = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+`;

--- a/src/components/signup/CenterName.jsx
+++ b/src/components/signup/CenterName.jsx
@@ -1,0 +1,75 @@
+import styled from 'styled-components';
+import { useState } from 'react';
+
+import Required from '../_common/Required';
+import Alert from './Alert';
+
+const CenterName = () => {
+  const [center, setCenter] = useState('');
+  const [validYn, setValidYn] = useState(true);
+
+  const isValidCenter = () => {
+    const centerList = []; // 백에서 가져오기
+
+    if (centerList.includes(center)) {
+      setValidYn(true);
+    } else {
+      setValidYn(false);
+    }
+  };
+
+  return (
+    <Container>
+      <div>
+        <label htmlFor="center">센터이름</label>
+        <Required />
+      </div>
+      <Wrapper>
+        <input
+          type="text"
+          placeholder="센터이름을 입력하세요."
+          value={center}
+          onChange={(e) => setCenter(e.target.value)}
+        />
+        <button onClick={isValidCenter}>센터 확인</button>
+      </Wrapper>
+      {!validYn && <Alert text="센터 이름을 확인해주세요" />}
+    </Container>
+  );
+};
+
+export default CenterName;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin-bottom: 8px;
+
+  label {
+    font-weight: bold;
+    font-size: 16px;
+  }
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  gap: 8px;
+
+  input {
+    height: 40px;
+    border: 1px solid #909090;
+    border-radius: 5px;
+    padding: 10px 15px;
+    font-size: 14px;
+    flex: 0.6;
+  }
+
+  button {
+    background-color: var(--green);
+    box-shadow: var(--shadow);
+    border-radius: 5px;
+    flex: 0.4;
+    cursor: pointer;
+  }
+`;

--- a/src/components/signup/Default.jsx
+++ b/src/components/signup/Default.jsx
@@ -1,0 +1,175 @@
+import styled from 'styled-components';
+import { useState } from 'react';
+
+import Dropdown from './Dropdown';
+import Required from '../_common/Required';
+
+const years = Array.from({ length: 2025 - 1930 + 1 }, (_, i) => 2025 - i);
+const months = Array.from({ length: 12 - 1 + 1 }, (_, i) => 1 + i);
+const days = Array.from({ length: 31 - 1 + 1 }, (_, i) => 1 + i);
+
+const Default = () => {
+  const [selected, setSelected] = useState('female');
+  const onChangeInput = () => {};
+
+  return (
+    <Container>
+      <Section className="name">
+        <Wrapper>
+          <label htmlFor="name">
+            이름
+            <Required />
+          </label>
+          <input
+            type="text"
+            id="name"
+            name="name"
+            placeholder="이름을 입력하세요."
+            value={name}
+            maxLength="4"
+            onChange={onChangeInput}
+          />
+        </Wrapper>
+        <Wrapper>
+          <label>
+            성별
+            <Required />
+          </label>
+          <ButtonContainer>
+            <button
+              className={selected === 'male' ? 'active' : ''}
+              onClick={() => setSelected('male')}
+            >
+              남
+            </button>
+            <button
+              className={selected === 'female' ? 'active' : ''}
+              onClick={() => setSelected('female')}
+            >
+              여
+            </button>
+          </ButtonContainer>
+        </Wrapper>
+      </Section>
+      <Section className="dateOfBirth">
+        <Wrapper className="dateOfBirth">
+          <label htmlFor="dob">
+            생년월일
+            <Required />
+          </label>
+          <DropdownWrapper>
+            <Dropdown options={years} width="40%" className="year" />
+            <Dropdown options={months} width="30%" className="month" />
+            <Dropdown options={days} width="30%" className="day" />
+          </DropdownWrapper>
+        </Wrapper>
+      </Section>
+      <Section className="tel">
+        <Wrapper className="tel">
+          <label htmlFor="tel">
+            휴대폰 번호
+            <Required />
+          </label>
+          <TelWrapper>
+            <input
+              type="text"
+              id="tel"
+              className="first"
+              placeholder="010"
+              name="tel1"
+            />
+            <input
+              type="text"
+              id="tel"
+              className="second"
+              placeholder="0000"
+              name="tel2"
+            />
+            <input
+              type="text"
+              id="tel"
+              className="third"
+              placeholder="0000"
+              name="tel3"
+            />
+          </TelWrapper>
+        </Wrapper>
+      </Section>
+    </Container>
+  );
+};
+
+export default Default;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 8px;
+`;
+
+const Section = styled.section`
+  width: 100%;
+  display: flex;
+
+  &.name {
+    justify-content: space-between;
+  }
+`;
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  label {
+    font-size: 16px;
+    margin-bottom: 4px;
+  }
+
+  input {
+    height: 40px;
+    border: 1px solid #909090;
+    border-radius: 5px;
+    padding: 10px 15px;
+    font-size: 14px;
+  }
+
+  &.dateOfBirth,
+  &.tel {
+    width: 100%;
+  }
+`;
+
+const DropdownWrapper = styled.div`
+  display: flex;
+  width: 100%;
+  gap: 8px;
+`;
+
+const TelWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  gap: 10px;
+
+  input {
+    flex: 1;
+    min-width: 0;
+  }
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  border-radius: 5px;
+  border: 1px solid #909090;
+
+  button {
+    height: 40px;
+    padding: 10px 20px;
+    border-radius: 5px;
+    cursor: pointer;
+
+    &.active {
+      background-color: var(--blue);
+      box-shadow: var(--shadow);
+    }
+  }
+`;

--- a/src/components/signup/Dropdown.jsx
+++ b/src/components/signup/Dropdown.jsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+export const Dropdown = ({ options = [], width }) => {
+  const [currentValue, setCurrentValue] = useState(options[0]);
+  const [showOptions, setShowOptions] = useState(false);
+
+  return (
+    <SelectBox onClick={() => setShowOptions((prev) => !prev)} width={width}>
+      <Label>{currentValue}</Label>
+      <SelectOptions show={showOptions}>
+        {options.map((data, index) => (
+          <Option
+            key={index}
+            value={data}
+            onClick={(e) => setCurrentValue(e.target.getAttribute('value'))}
+          >
+            {data}
+          </Option>
+        ))}
+      </SelectOptions>
+    </SelectBox>
+  );
+};
+
+export default Dropdown;
+
+const SelectBox = styled.div`
+  position: relative;
+  height: 40px;
+  width: ${(props) => props.width};
+  padding: 15px;
+  border-radius: 5px;
+  background-color: #ffffff;
+  align-self: center;
+  border: 1px solid #909090;
+  cursor: pointer;
+
+  &::before {
+    content: '⌵';
+    position: absolute;
+    top: 4px;
+    right: 15px;
+    color: #666666;
+    font-size: 20px;
+    font-weight: bold;
+  }
+`;
+
+const Label = styled.p`
+  font-size: 14px;
+  display: inline-block;
+
+  position: relative;
+  bottom: 8px;
+`;
+
+const SelectOptions = styled.ul`
+  position: absolute;
+  top: 40px;
+  left: 0;
+  width: 100%;
+  overflow-y: auto;
+  border-radius: 10px;
+  max-height: ${(props) => (props.show ? '500px' : '0')};
+  background-color: white;
+  box-shadow: var(--shadow);
+  z-index: 10;
+
+  // 스크롤바 CSS
+  ::-webkit-scrollbar {
+    width: 4px;
+    height: 200px;
+  }
+  ::-webkit-scrollbar-thumb {
+    background-color: gray;
+    border-radius: 30px;
+  }
+  ::-webkit-scrollbar-track {
+    background-color: gray;
+    border-radius: 30px;
+  }
+`;
+
+const Option = styled.li`
+  font-size: 14px;
+  padding: 12px 18px;
+  height: 40px;
+  transition: background-color 0.2s ease-in;
+  border-bottom: 1px solid #909090;
+
+  &:hover {
+    color: white;
+    border-radius: 5px;
+    background: linear-gradient(135deg, #5658df 0%, #2f6dd0 100%);
+  }
+`;

--- a/src/components/signup/Email.jsx
+++ b/src/components/signup/Email.jsx
@@ -1,0 +1,96 @@
+import styled from 'styled-components';
+import { useState } from 'react';
+
+import Required from '../_common/Required';
+import Alert from './Alert';
+
+const Email = () => {
+  const [matchYn, setMatchYn] = useState(true);
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
+
+  const isValidCode = () => {
+    const answer = '1234'; // 백에서 받아오기
+
+    if (code === answer) {
+      setMatchYn(true);
+    } else {
+      setMatchYn(false);
+    }
+  };
+
+  const getCode = () => {};
+
+  return (
+    <Container>
+      <div>
+        <label htmlFor="email">아이디(이메일)</label>
+        <Required />
+      </div>
+      <InputWrapper>
+        <Wrapper>
+          <Input
+            placeholder="abc@email.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <Button onClick={getCode}>인증번호 받기</Button>
+        </Wrapper>
+        <div>
+          <Wrapper>
+            <Input
+              placeholder="인증번호"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+            />
+            <Button onClick={isValidCode}>인증번호 확인</Button>
+          </Wrapper>
+          {!matchYn && (
+            <Alert text="인증번호가 일치하지 않습니다. 다시 확인해주세요." />
+          )}
+        </div>
+      </InputWrapper>
+    </Container>
+  );
+};
+
+export default Email;
+
+const Container = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin-bottom: 8px;
+
+  label {
+    font-size: 16px;
+  }
+`;
+const InputWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+const Wrapper = styled.div`
+  display: flex;
+  gap: 10px;
+`;
+
+const Input = styled.input`
+  height: 40px;
+  border: 1px solid #909090;
+  border-radius: 5px;
+  padding: 10px 15px;
+  font-size: 14px;
+  flex: 0.7;
+`;
+
+const Button = styled.button`
+  height: 40px;
+  flex: 0.3;
+  background-color: var(--green);
+  box-shadow: var(--shadow);
+  padding: 10px 20px;
+  border-radius: 5px;
+  cursor: pointer;
+`;

--- a/src/components/signup/Password.jsx
+++ b/src/components/signup/Password.jsx
@@ -1,0 +1,120 @@
+import styled from 'styled-components';
+import { useState } from 'react';
+
+import Required from '../_common/Required';
+import Alert from './Alert';
+
+const isValidPassword = (password) => {
+  if (password.length < 6 || password.length > 20) {
+    return false;
+  }
+
+  const hasUpperCase = /[A-Z]/.test(password);
+  const hasLowerCase = /[a-z]/.test(password);
+  const hasNumber = /\d/.test(password);
+  const hasSpecialChar = /[!@#$%^&*()-_]/.test(password);
+
+  const conditionCount = [
+    hasUpperCase,
+    hasLowerCase,
+    hasNumber,
+    hasSpecialChar,
+  ].filter(Boolean).length;
+
+  return conditionCount >= 2;
+};
+
+const Password = () => {
+  const [pw, setPw] = useState('');
+  const [checkPw, setCheckPw] = useState('');
+  const [errorType, setErrorType] = useState('none');
+
+  const onChangePw = (e) => {
+    const newPw = e.target.value;
+    setPw(newPw);
+
+    if (!isValidPassword(newPw)) {
+      setErrorType('invalid'); // 비밀번호 형식 오류
+    } else if (checkPw && newPw !== checkPw) {
+      setErrorType('mismatch'); // 비밀번호 확인과 불일치
+    } else {
+      setErrorType('none'); // 정상
+    }
+  };
+
+  const onChangeCheckPw = (e) => {
+    const newCheckPw = e.target.value;
+    setCheckPw(newCheckPw);
+
+    if (newCheckPw !== pw) {
+      setErrorType('mismatch'); // 비밀번호와 불일치
+    } else if (isValidPassword(pw)) {
+      setErrorType('none'); // 정상
+    }
+  };
+
+  return (
+    <Container>
+      <div>
+        <label htmlFor="pw">비밀번호</label>
+        <Required />
+      </div>
+      <Wrapper>
+        <Input
+          id="pw"
+          type="password"
+          placeholder="비밀번호"
+          value={pw}
+          onChange={onChangePw}
+        />
+        {errorType === 'invalid' ? (
+          <Alert text="비밀번호를 다시 확인해주세요." />
+        ) : (
+          <Blank />
+        )}
+        <Input
+          type="password"
+          placeholder="비밀번호 확인"
+          value={checkPw}
+          onChange={onChangeCheckPw}
+        />
+        {errorType === 'mismatch' && (
+          <Alert text="비밀번호가 일치하지 않습니다. 다시 확인해주세요." />
+        )}
+        <p>6-20자/영문 대문자, 소문자, 숫자, 특수문자 중 2가지 이상 조합</p>
+      </Wrapper>
+    </Container>
+  );
+};
+
+export default Password;
+
+const Container = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin-bottom: 8px;
+`;
+
+const Blank = styled.div`
+  height: 10px;
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  p {
+    font-size: 12px;
+    font-weight: bold;
+  }
+`;
+
+const Input = styled.input`
+  height: 40px;
+  border: 1px solid #909090;
+  border-radius: 5px;
+  padding: 10px 15px;
+  font-size: 14px;
+  flex: 1;
+`;

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,7 @@
 :root {
   --green: #c1e678;
   --blue: #3093f0;
+  --red: #ff0000;
   --shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
 }
 
@@ -21,6 +22,7 @@
   min-width: 300px;
   max-width: 600px;
   padding: 0 20px;
+  padding-bottom: 20px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter } from 'react-router-dom';
 import { createRoot } from 'react-dom/client';
 
+
 import './index.css';
 import App from './App.jsx';
 

--- a/src/pages/KakaoAuthPage.jsx
+++ b/src/pages/KakaoAuthPage.jsx
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+import { sendCode } from '../api/user';
+
+const KakaoAuthPage = () => {
+  useEffect(() => {
+    const params = new URL(document.location.toString()).searchParams;
+    const code = params.get('code') || '';
+
+    const login = async () => {
+      const res = await sendCode(code);
+      const data = res?.data;
+
+      if (data) {
+        // 회원인지 아닌지 판단
+
+        // 회원이면 사용자 정보를 다 받아서 recoil에 저장
+        // setLogin({
+        //   nickname: data.nickname,
+        //   email: data.email,
+        //   accessToken: data.accessToken,
+        //   refreshToken: data.refreshToken,
+        //   isfirst: data.isfirst,
+        // });
+
+        // 로그인 처리 & 메인 페이지로 이동
+        window.localStorage.setItem('accessToken', data.accessToken);
+        window.location.href = '/';
+
+        // 회원이 아니면 사용자 정보를 일부 받기(이름, 연락처 등) -> 카카오로 회원가입하기 (개인 or 기업) 페이지로 연결
+      }
+      // data가 안오면 카카오 로그인 실패 -> '카카오 계정을 가져오지 못했습니다' 모달창 띄우기
+    };
+
+    login();
+  }, []);
+
+  return <></>;
+};
+
+export default KakaoAuthPage;

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -4,6 +4,8 @@ import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 
 import Title from '../components/_common/Title';
+import Header from '../components/_common/Header';
+import RoundButton from '../components/_common/RoundButton';
 import chatBubble from '../assets/chat_bubble.png';
 
 const Login = () => {
@@ -30,7 +32,8 @@ const Login = () => {
   };
 
   return (
-    <div>
+    <Container>
+      <Header />
       <Title mb="60">
         <p>로그인/회원가입</p>
       </Title>
@@ -64,18 +67,26 @@ const Login = () => {
         </PwWrapper>
       </LoginSection>
       <ButtonSection>
-        <Button className="login" onClick={onLoginClick}>
+        <RoundButton color="green" text="로그인" onClick={onLoginClick}>
           로그인
-        </Button>
-        <Button className="signUp" onClick={() => nav(`/signupselect/email`)}>
+        </RoundButton>
+        <RoundButton
+          color="blue"
+          text="이메일로 회원가입하기"
+          onClick={() => nav(`/signupselect/email`)}
+        >
           이메일로 회원가입하기
-        </Button>
+        </RoundButton>
       </ButtonSection>
-    </div>
+    </Container>
   );
 };
 
 export default Login;
+
+const Container = styled.div`
+  margin-top: 100px;
+`;
 
 const KakaoButton = styled.button`
   width: 100%;
@@ -136,29 +147,12 @@ const PwWrapper = styled.div`
 
   span {
     font-size: 12px;
+    cursor: pointer;
   }
 `;
 
 const ButtonSection = styled.div`
   display: flex;
   flex-direction: column;
-`;
-
-const Button = styled.button`
-  width: 100%;
-  height: 45px;
-
-  border-radius: 30px;
-  box-shadow: var(--shadow);
-  font-size: 16px;
-  cursor: pointer;
-
-  &.login {
-    background-color: var(--green);
-    margin-bottom: 5px;
-  }
-
-  &.signUp {
-    background-color: var(--blue);
-  }
+  gap: 5px;
 `;

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -1,21 +1,60 @@
 import { useParams } from 'react-router-dom';
+import styled from 'styled-components';
+import { RecoilRoot } from 'recoil';
 
-import Title from '../components/_common/Title';
 import { getTargetKr, getTypeKr } from '../util/get-kr-word';
+import Header from '../components/_common/Header';
+import Title from '../components/_common/Title';
+import Default from '../components/signup/Default';
+import AddressInput from '../components/signup/AdressInput';
+import CenterName from '../components/signup/CenterName';
+import Center from '../components/signup/Center';
+import Email from '../components/signup/Email';
+import Password from '../components/signup/Password';
+import RoundButton from '../components/_common/RoundButton';
+import { useRecoilState } from 'recoil';
 
 const SignUp = () => {
   const params = useParams();
-
   const { type, target } = params;
 
+  const onSubmit = () => {};
+
   return (
-    <div>
-      <Title>
-        <p>{getTypeKr(type)}로</p>
-        <p>회원가입 하기({getTargetKr(target)})</p>
-      </Title>
-    </div>
+    <RecoilRoot>
+      <Container>
+        <div>
+          <Header />
+          <Title mb={type === 'kakao' && target === 'individual' ? '70' : '20'}>
+            <p>{getTypeKr(type)}로</p>
+            <p>회원가입 하기({getTargetKr(target)})</p>
+          </Title>
+          {type === 'email' && (
+            <>
+              <Email />
+              <Password />
+            </>
+          )}
+          <Default />
+          {target === 'center' && <CenterName />}
+          <AddressInput />
+          {target === 'center' && <Center />}
+        </div>
+        <RoundButton
+          text="회원가입 완료"
+          color="green"
+          onClick={onSubmit}
+          mt={type === 'kakao' && target === 'individual' ? '60' : '20'}
+        />
+      </Container>
+    </RecoilRoot>
   );
 };
 
 export default SignUp;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-top: 100px;
+`;

--- a/src/pages/SignUpSelect.jsx
+++ b/src/pages/SignUpSelect.jsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
 
 import Title from '../components/_common/Title';
+import Header from '../components/_common/Header';
 import { getTypeKr } from '../util/get-kr-word';
 
 // 개인 회원인지 기업 회원인지 고르는 페이지
@@ -12,7 +13,8 @@ const SignUpSelect = () => {
   const nav = useNavigate(); // 회원가입 기업 or 개인 페이지로 이동
 
   return (
-    <div>
+    <Container>
+      <Header /> 
       <Title mb="100">
         <p>{getTypeKr(type)}로</p>
         <p>회원가입 하기</p>
@@ -24,15 +26,22 @@ const SignUpSelect = () => {
         >
           개인 회원
         </Button>
-        <Button className="group" onClick={() => nav(`/signup/${type}/group`)}>
+        <Button
+          className="center"
+          onClick={() => nav(`/signup/${type}/center`)}
+        >
           기업 회원
         </Button>
       </ButtonWrapper>
-    </div>
+    </Container>
   );
 };
 
 export default SignUpSelect;
+
+const Container = styled.div`
+  margin-top: 100px;
+`;
 
 const ButtonWrapper = styled.div`
   display: flex;
@@ -51,7 +60,7 @@ const Button = styled.button`
     background-color: var(--green);
   }
 
-  &.group {
+  &.center {
     background-color: var(--blue);
   }
 `;

--- a/src/recoil/SignUp.js
+++ b/src/recoil/SignUp.js
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+export const SignUpInfoAtom = atom({
+  key: 'SignUpInfoAtom',
+  default: {
+    name: '',
+  },
+});

--- a/src/util/get-kr-word.js
+++ b/src/util/get-kr-word.js
@@ -13,7 +13,7 @@ export const getTargetKr = (target) => {
   switch (target) {
     case 'individual':
       return '개인';
-    case 'group':
+    case 'center':
       return '기업';
   }
 };


### PR DESCRIPTION
# 구현 기능

- 둥근 버튼 공용 컴포넌트 구현
- 로그인/회원가입 페이지 퍼블리싱

# 구현 상태
![image](https://github.com/user-attachments/assets/583c3870-8d2f-433a-ab2c-9877f25429a5)
![image](https://github.com/user-attachments/assets/23a8d01c-dc02-484e-9f75-a2ce7020ebb0) ![image](https://github.com/user-attachments/assets/f01d7469-7196-4a63-b47b-bad57622e389)

# To Reviewers
- 둥근 버튼 컴포넌트는 텍스트, 색상, margin-top, 클릭 시 처리할 함수를 prop으로 받습니다.
- 우편 번호 찾기는 추후에 모달창을 만들어서 띄울 예정입니다.
