### PR TITLE
feat: 상세 보기 페이지 모달로 변경

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,9 +25,6 @@ import Recruiting from './pages/Recruiting';
 import EditCenterInfo from './pages/EditCenterInfo';
 import EditManagerInfo from './pages/EditManagerInfo';
 import EditCareWorkerInfo from './pages/EditCareWorkerInfo';
-import SeniorSpecifics from './pages/SeniorSpecifics';
-import CareWorkerSpecifics from './pages/CareWorkerSpecifics';
-import RecruitingSpecifics from './pages/RecruitingSpecifics';
 
 function App() {
   return (
@@ -63,15 +60,6 @@ function App() {
         <Route
           path="/editcareworkerinfo/:id"
           element={<EditCareWorkerInfo />}
-        />
-        <Route path="/seniorspecifics/:id" element={<SeniorSpecifics />} />
-        <Route
-          path="/careworkerspecifics/:id"
-          element={<CareWorkerSpecifics />}
-        />
-        <Route
-          path="/recruitingspecifics/:id"
-          element={<RecruitingSpecifics />}
         />
       </Routes>
     </>

--- a/src/components/chat/SeniorChatProfile.jsx
+++ b/src/components/chat/SeniorChatProfile.jsx
@@ -50,7 +50,7 @@ const SeniorChatProfile = ({ isAccepted }) => {
         </BtnDiv>
       )}
       <div className="margin" />
-      {isOpen && <ContractModal setIsOpen={setIsOpen} />}
+      {isOpen && <ContractModal setIsOpen={setIsOpen} type="senior" />}
     </Div>
   );
 };

--- a/src/components/chat/WorkerChatProfile.jsx
+++ b/src/components/chat/WorkerChatProfile.jsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { useEffect, useState } from 'react';
 
 import arrow from '../../assets/arrow-right.png';
+import ContractModal from './contract/ContractModal';
 
 const WorkerChatProfile = () => {
   // 요양사 상세보기 모달
@@ -18,7 +19,7 @@ const WorkerChatProfile = () => {
   return (
     <Div>
       <Title>요양보호사 상세정보 보기</Title>
-      <BoxDiv>
+      <BoxDiv onClick={() => setIsOpen(true)}>
         <Content>
           <p className="dot">성별: 여</p>
           <p className="dot">나이: 78세</p>
@@ -42,6 +43,7 @@ const WorkerChatProfile = () => {
           <img src={arrow} />
         </div>
       </BoxDiv>
+      {isOpen && <ContractModal setIsOpen={setIsOpen} type="careWorker" />}
     </Div>
   );
 };

--- a/src/components/chat/contract/ContractModal.jsx
+++ b/src/components/chat/contract/ContractModal.jsx
@@ -2,10 +2,11 @@ import styled from 'styled-components';
 
 import SquareButton from '../../_common/SquareButton';
 import Contract from './Contract';
+import CareWorkerDetail from '../../detailmodal/CareWorkerDetail';
 
 import close from '../../../assets/close.png';
 
-const ContractModal = ({ setIsOpen }) => {
+const ContractModal = ({ setIsOpen, type }) => {
   return (
     <Overlay>
       <ModalWrapper>
@@ -13,12 +14,14 @@ const ContractModal = ({ setIsOpen }) => {
           <img src={close} onClick={() => setIsOpen(false)} />
         </CloseButton>
         <Content>
-          <Contract />
+          {type === 'senior' ? <Contract /> : <CareWorkerDetail />}
         </Content>
-        <ButtonWrapper>
-          <SquareButton color={'blue'}>거절</SquareButton>
-          <SquareButton color={'green'}>수락</SquareButton>
-        </ButtonWrapper>
+        {type === 'senior' && (
+          <ButtonWrapper>
+            <SquareButton color={'blue'}>거절</SquareButton>
+            <SquareButton color={'green'}>수락</SquareButton>
+          </ButtonWrapper>
+        )}
       </ModalWrapper>
     </Overlay>
   );

--- a/src/components/detailmodal/CareWorkerDetail.jsx
+++ b/src/components/detailmodal/CareWorkerDetail.jsx
@@ -1,14 +1,12 @@
 import styled from 'styled-components';
 
-import Header from '../components/_common/Header';
-import checkCircle from '../assets/checkCircle.svg';
-import { CheckboxStyle } from '../util/common-style';
-import { getOptions } from '../util/get-options';
+import checkCircle from '../../assets/checkCircle.svg';
+import { CheckboxStyle } from '../../util/common-style';
+import { getOptions } from '../../util/get-options';
 
-const CareWorkerSpecifics = () => {
+const CareWorkerDetail = () => {
   return (
     <Container>
-      <Header title="요양보호사 정보" />
       <Wrapper>
         <Title>개인 정보</Title>
         <ImgWrapper>
@@ -149,10 +147,9 @@ const CareWorkerSpecifics = () => {
   );
 };
 
-export default CareWorkerSpecifics;
+export default CareWorkerDetail;
 
 const Container = styled.div`
-  margin-top: 100px;
   gap: 100px;
   display: flex;
   flex-direction: column;

--- a/src/components/detailmodal/DetailModal.jsx
+++ b/src/components/detailmodal/DetailModal.jsx
@@ -1,0 +1,96 @@
+import styled from 'styled-components';
+import cross from '../../assets/cross.png';
+
+import CareWorkerDetail from './CareWorkerDetail';
+import SeniorDetails from './SeniorDetail';
+import RecruitingDetail from './RecruitingDetail';
+
+const DetailModal = ({ type, isOpen, onClose }) => {
+  if (!isOpen) return null;
+
+  const Content =
+    type === 'careworker' ? (
+      <CareWorkerDetail />
+    ) : type === 'senior' ? (
+      <SeniorDetails />
+    ) : type === 'recruiting' ? (
+      <RecruitingDetail />
+    ) : null;
+
+  return (
+    <Container>
+      <Overlay onClick={onClose} />
+      <ModalWrapper>
+        <Cross onClick={onClose}>
+          <img src={cross} alt="Close" />
+        </Cross>
+        <ContentWrapper>{Content}</ContentWrapper>
+      </ModalWrapper>
+    </Container>
+  );
+};
+
+export default DetailModal;
+
+const Container = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  z-index: 5000;
+  top: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: transparent;
+`;
+
+const Overlay = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 2000;
+  top: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const ModalWrapper = styled.div`
+  max-height: 90vh;
+  min-width: 260px;
+  max-width: 560px;
+  width: calc(100% - 40px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: white;
+  border-radius: 10px;
+  box-shadow: var(--shadow);
+  z-index: 2500;
+  overflow-y: auto;
+  position: relative;
+  padding: 20px;
+`;
+
+const Cross = styled.div`
+  position: fixed;
+  width: calc(100% - 40px);
+  padding-right: 20px;
+  display: flex;
+  justify-content: end;
+  img {
+    width: 24px;
+    height: 24px;
+    cursor: pointer;
+  }
+`;
+
+const ContentWrapper = styled.div`
+  margin-top: 40px;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;

--- a/src/components/detailmodal/RecruitingDetail.jsx
+++ b/src/components/detailmodal/RecruitingDetail.jsx
@@ -1,13 +1,11 @@
 import styled from 'styled-components';
 
-import Header from '../components/_common/Header';
-import { CheckboxStyle } from '../util/common-style';
-import { getOptions } from '../util/get-options';
+import { CheckboxStyle } from '../../util/common-style';
+import { getOptions } from '../../util/get-options';
 
-const RecruitingSpecifics = () => {
+const RecruitingDetail = () => {
   return (
     <Container>
-      <Header title="구인 정보" />
       <Wrapper>
         <Title>어르신 정보</Title>
         <ImgWrapper>
@@ -185,15 +183,9 @@ const RecruitingSpecifics = () => {
   );
 };
 
-export default RecruitingSpecifics;
-
-const CheckBoxRow = styled.div`
-  display: flex;
-  justify-content: space-between;
-`;
+export default RecruitingDetail;
 
 const Container = styled.div`
-  margin-top: 100px;
   display: flex;
   flex-direction: column;
   gap: 100px;
@@ -239,6 +231,11 @@ const Key = styled.p`
 const Val = styled.p`
   font-size: 24px;
   font-weight: bold;
+`;
+
+const CheckBoxRow = styled.div`
+  display: flex;
+  justify-content: space-between;
 `;
 
 const CheckboxWrapper = styled.div`

--- a/src/components/detailmodal/SeniorDetail.jsx
+++ b/src/components/detailmodal/SeniorDetail.jsx
@@ -1,15 +1,16 @@
 import styled from 'styled-components';
 
-import Header from '../components/_common/Header';
-import { CheckboxStyle } from '../util/common-style';
-import { getOptions } from '../util/get-options';
+import { CheckboxStyle } from '../../util/common-style';
+import { getOptions } from '../../util/get-options';
 
-const SeniorSpecifics = () => {
+const SeniorDetail = ({ edit }) => {
   return (
     <Container>
-      <Header title="어르신 정보" />
       <Wrapper>
-        <Title>개인 정보</Title>
+        <div className="header">
+          <Title>개인 정보</Title>
+          {edit && <Edit>수정하기</Edit>}
+        </div>
         <ImgWrapper>
           <img src="" />
         </ImgWrapper>
@@ -66,10 +67,9 @@ const SeniorSpecifics = () => {
   );
 };
 
-export default SeniorSpecifics;
+export default SeniorDetail;
 
 const Container = styled.div`
-  margin-top: 100px;
   display: flex;
   flex-direction: column;
   user-select: none;
@@ -79,6 +79,12 @@ const Wrapper = styled.section`
   display: flex;
   flex-direction: column;
   gap: 20px;
+
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
 `;
 
 const ItemWrapper = styled.div`
@@ -129,4 +135,9 @@ const CheckboxWrapper = styled.div`
 
 const CheckBox = styled.input`
   ${CheckboxStyle}
+`;
+
+const Edit = styled.span`
+  text-decoration: underline;
+  cursor: pointer;
 `;


### PR DESCRIPTION
# 구현 기능
- 상세 보기 페이지들을 전부 모달로 변경했습니다.

# 구현 상태
![image](https://github.com/user-attachments/assets/569f4978-9ca9-4f9d-9353-d9f363b99258)


# To Reviewers
- components > detailmodal 아래에 모달의 기본 틀과 그 안에 들어갈 정보를 요양사, 어르신, 구인 정보 별로 나눠서 타입으로 받도록 구현했습니다.
- 채팅 페이지에서도 요양보호사 상세보기를 누르면 요양사 상세 정보 모달이 띄워지도록 구현했습니다.
