### PR TITLE
fix: css 및 오류 수정 & 어르신 정보 수정 페이지 퍼블리싱

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -57,7 +57,7 @@ function App() {
         <Route path="/careworkerinfo/:order" element={<CareWorkerInfo />} />
         <Route path="/chat/:id" element={<Chat />} />
         <Route path="/list/senior" element={<SeniorList />} />
-        <Route path="/list/job" element={<JobList />} />
+        <Route path="/list/recruit" element={<JobList />} />
         <Route path="/menu" element={<Menu />} />
         <Route path="/history" element={<WorkerHistory />} />
         <Route path="/calendar" element={<WorkerCalendar />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,8 @@ import './App.css';
 import Splash from './pages/Splash';
 import Home from './pages/Home';
 import MyPage from './pages/MyPage';
+import ManagerMyPage from './components/mypage/ManagerMyPage';
+import WorkerMyPage from './components/mypage/WorkerMyPage';
 import Login from './pages/Login';
 import SignUp from './pages/SignUp';
 import SignUpSelect from './pages/SignUpSelect';
@@ -39,7 +41,10 @@ function App() {
       <Routes>
         <Route path="/" element={<Splash />} />
         <Route path="/home/:type" element={<Home />} />
-        <Route path="/mypage" element={<MyPage />} />
+        <Route path="/mypage" element={<MyPage />}>
+          <Route path="manager" element={<ManagerMyPage />} />
+          <Route path="careworker" element={<WorkerMyPage />} />
+        </Route>
         <Route path="/login" element={<Login />} />
         <Route path="/signupselect/:type" element={<SignUpSelect />} />
         <Route path="/signup/:type/:target" element={<SignUp />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,6 +27,7 @@ import Recruiting from './pages/Recruiting';
 import EditCenterInfo from './pages/EditCenterInfo';
 import EditManagerInfo from './pages/EditManagerInfo';
 import EditCareWorkerInfo from './pages/EditCareWorkerInfo';
+import EditSeniorInfo from './pages/EditSeniorInfo';
 import Dashboard from './pages/Dashboard';
 import DashMain from './components/dashboard/main/DashMain';
 import DashStatus from './components/dashboard/status/DashStatus';
@@ -73,6 +74,7 @@ function App() {
           path="/editcareworkerinfo/:id"
           element={<EditCareWorkerInfo />}
         />
+        <Route path="/editseniorinfo/:id" element={<EditSeniorInfo />} />
         <Route path="/dashboard" element={<Dashboard />}>
           <Route path="" element={<DashMain />} />
           <Route path="status" element={<DashStatus />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,10 +30,12 @@ import DashMain from './components/dashboard/main/DashMain';
 import DashStatus from './components/dashboard/status/DashStatus';
 import DashMatching from './components/dashboard/matching/DashMatching';
 import MatchingList from './pages/MatchingList';
+import ScrollToTop from './util/ScollToTop';
 
 function App() {
   return (
     <>
+      <ScrollToTop />
       <Routes>
         <Route path="/" element={<Splash />} />
         <Route path="/home/:type" element={<Home />} />

--- a/src/components/chat/contract/ContractModal.jsx
+++ b/src/components/chat/contract/ContractModal.jsx
@@ -41,7 +41,7 @@ const Overlay = styled.div`
 `;
 
 const ModalWrapper = styled.div`
-  max-height: 90vh;
+  max-height: 90svh;
   min-width: 260px;
   max-width: 560px;
   width: calc(100% - 40px);

--- a/src/components/chat/contract/ContractModal.jsx
+++ b/src/components/chat/contract/ContractModal.jsx
@@ -65,8 +65,8 @@ const CloseButton = styled.div`
   display: flex;
   justify-content: end;
   img {
-    width: 24px;
-    height: 24px;
+    width: 35px;
+    height: 35px;
     cursor: pointer;
   }
 `;

--- a/src/components/detailmodal/CareWorkerDetail.jsx
+++ b/src/components/detailmodal/CareWorkerDetail.jsx
@@ -10,7 +10,7 @@ const CareWorkerDetail = () => {
       <Wrapper>
         <Title>개인 정보</Title>
         <ImgWrapper>
-          <img src="" />
+          <img src={null} />
         </ImgWrapper>
         <Div>
           <FixedWrapper>
@@ -36,10 +36,10 @@ const CareWorkerDetail = () => {
         </FixedWrapper>
         <FixedWrapper>
           <Key>자격증</Key>
-          <Val>
-            <p>요양보호사 1급</p>
-            <p>2014-0000</p>
-          </Val>
+          <div>
+            <Val>요양보호사 1급</Val>
+            <Val>2014-0000</Val>
+          </div>
         </FixedWrapper>
         <FixedWrapper className="row">
           <Key>차량소유 여부</Key>
@@ -61,10 +61,10 @@ const CareWorkerDetail = () => {
               <span>협의 가능</span>
             </div>
           </div>
-          <Val>
-            <p>목 12:00 ~ 14:00</p>
-            <p>금 12:00 ~ 14:00</p>
-          </Val>
+          <div>
+            <Val>목 12:00 ~ 14:00</Val>
+            <Val>금 12:00 ~ 14:00</Val>
+          </div>
         </FixedWrapper>
         <FixedWrapper>
           <Key>희망 시급</Key>
@@ -72,10 +72,10 @@ const CareWorkerDetail = () => {
         </FixedWrapper>
         <FixedWrapper>
           <Key>희망 근무지역</Key>
-          <Val>
-            <p>서울 특별시 마포구 합정동</p>
-            <p>서울 특별시 서대문구 대현동</p>
-          </Val>
+          <div>
+            <Val>서울 특별시 마포구 합정동</Val>
+            <Val>서울 특별시 서대문구 대현동</Val>
+          </div>
         </FixedWrapper>
 
         <FixedWrapper className="list">

--- a/src/components/detailmodal/DetailModal.jsx
+++ b/src/components/detailmodal/DetailModal.jsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import cross from '../../assets/cross.png';
+import close from '../../assets/close.png';
 
 import CareWorkerDetail from './CareWorkerDetail';
 import SeniorDetails from './SeniorDetail';
@@ -21,8 +21,8 @@ const DetailModal = ({ type, isOpen, onClose }) => {
     <Container>
       <Overlay onClick={onClose} />
       <ModalWrapper>
-        <Cross onClick={onClose}>
-          <img src={cross} alt="Close" />
+        <Cross>
+          <img onClick={onClose} src={close} alt="Close" />
         </Cross>
         <ContentWrapper>{Content}</ContentWrapper>
       </ModalWrapper>
@@ -84,8 +84,8 @@ const Cross = styled.div`
   display: flex;
   justify-content: end;
   img {
-    width: 24px;
-    height: 24px;
+    width: 35px;
+    height: 35px;
     cursor: pointer;
   }
 `;

--- a/src/components/list/MathcingListItem.jsx
+++ b/src/components/list/MathcingListItem.jsx
@@ -1,21 +1,29 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import WorkerDetailedItem from './WorkerDetailedItem';
 import Card from '../_common/Card';
+import SquareButton from '../_common/SquareButton';
+import Modal from '../_common/Modal';
 
 import chevron from '../../assets/chevron-right.png';
-import SquareButton from '../_common/SquareButton';
-import DetailModal from '../detailmodal/DetailModal';
 
 const MathcingListItem = ({ id, name, age, addr, profile, workers, type }) => {
   const [isCardOpen, setIsCardOpen] = useState(false);
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isTerminationModalOpen, setIsTerminationModalOpen] = useState(false);
+
+  const nav = useNavigate();
+
+  const handleTerminationClick = (e) => {
+    e.stopPropagation();
+    setIsTerminationModalOpen(true);
+  };
 
   return (
     <div>
       {isCardOpen ? (
-        <OpenedCardDiv onClick={() => setIsModalOpen(true)}>
+        <OpenedCardDiv onClick={() => nav(`/editseniorinfo/${id}`)}>
           <CardDiv>
             <div className="img-box">
               <img src={profile} />
@@ -35,7 +43,9 @@ const MathcingListItem = ({ id, name, age, addr, profile, workers, type }) => {
               return <WorkerDetailedItem key={index} data={item} type={type} />;
             })}
             {type === 'acceptance' && (
-              <SquareButton color="white">계약종료</SquareButton>
+              <SquareButton color="white" onClick={handleTerminationClick}>
+                계약종료
+              </SquareButton>
             )}
           </WorkerDiv>
         </OpenedCardDiv>
@@ -51,10 +61,15 @@ const MathcingListItem = ({ id, name, age, addr, profile, workers, type }) => {
           <p>{addr}</p>
         </Card>
       )}
-      <DetailModal
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-        type={'senior'}
+      <Modal
+        isOpen={isTerminationModalOpen}
+        onClose={() => setIsTerminationModalOpen(false)}
+        btnText1={'아니오'}
+        btnText2={'예'}
+        onClick1={() => setIsTerminationModalOpen(false)}
+        onClick2={() => console.log('계약 종료 api 연결 예정')}
+        text={'매칭을 종료하시겠습니까?'}
+        type={'confirm'}
       />
     </div>
   );

--- a/src/components/list/WorkerDetailedItem.jsx
+++ b/src/components/list/WorkerDetailedItem.jsx
@@ -10,7 +10,7 @@ const WorkerDetailedItem = ({ data, type }) => {
   const nav = useNavigate();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const handleClick = (e) => {
+  const handleSeniorClick = (e) => {
     e.stopPropagation();
 
     if (type === 'acceptance') {
@@ -21,8 +21,13 @@ const WorkerDetailedItem = ({ data, type }) => {
     }
   };
 
+  const handleModalClick = (e) => {
+    e.stopPropagation();
+    setIsModalOpen(false);
+  };
+
   return (
-    <Item onClick={handleClick}>
+    <Item onClick={handleSeniorClick}>
       <CheckBox />
       <TextDiv>
         <div className="text-div">
@@ -36,7 +41,7 @@ const WorkerDetailedItem = ({ data, type }) => {
       </TextDiv>
       <DetailModal
         isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
+        onClose={handleModalClick}
         type={'careworker'}
       />
     </Item>

--- a/src/components/mypage/ManagerMyPage.jsx
+++ b/src/components/mypage/ManagerMyPage.jsx
@@ -1,0 +1,51 @@
+import { useNavigate } from 'react-router-dom';
+import ManagerButtonBox from './manager/ManagerButtonBox';
+import ManagerMatchingList from './manager/ManagerMatchingList';
+import ManagerProfile from './manager/ManagerProfile';
+
+import chevron from '../../assets/chevron-right.png';
+import styled from 'styled-components';
+
+const ManagerMyPage = () => {
+  const nav = useNavigate();
+
+  return (
+    <div>
+      <ManagerProfile />
+      <DashboardDiv onClick={() => nav('/dashboard')}>
+        <p>대시보드 바로가기</p>
+        <img src={chevron} />
+      </DashboardDiv>
+      <ManagerButtonBox />
+      <ManagerMatchingList />
+    </div>
+  );
+};
+
+const DashboardDiv = styled.button`
+  width: 100%;
+  height: 70px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  border-radius: 15px;
+  background-color: var(--blue);
+  box-shadow: var(--shadow);
+  color: #ffffff;
+  margin-top: 40px;
+  p {
+    font-size: 24px;
+    font-weight: 700;
+  }
+  img {
+    -webkit-filter: brightness(0) invert(1);
+    filter: brightness(0) invert(1);
+    width: 24px;
+    height: 24px;
+    position: absolute;
+    right: 20px;
+  }
+`;
+
+export default ManagerMyPage;

--- a/src/components/mypage/ManagerMyPage.jsx
+++ b/src/components/mypage/ManagerMyPage.jsx
@@ -12,6 +12,14 @@ const ManagerMyPage = () => {
   return (
     <div>
       <ManagerProfile />
+      <ButtonDiv>
+        <button onClick={() => nav(`/editmanagerinfo/${1}`)}>
+          개인정보 수정하기
+        </button>
+        <button onClick={() => nav(`/editcenterinfo/${1}`)}>
+          센터정보 수정하기
+        </button>
+      </ButtonDiv>
       <DashboardDiv onClick={() => nav('/dashboard')}>
         <p>대시보드 바로가기</p>
         <img src={chevron} />
@@ -21,6 +29,21 @@ const ManagerMyPage = () => {
     </div>
   );
 };
+
+const ButtonDiv = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  gap: 10px;
+  padding-top: 20px;
+  button {
+    width: 100%;
+    font-size: 16px;
+    padding: 2px 14px;
+    border-radius: 20px;
+    background-color: #e5e5e5;
+  }
+`;
 
 const DashboardDiv = styled.button`
   width: 100%;
@@ -33,7 +56,7 @@ const DashboardDiv = styled.button`
   background-color: var(--blue);
   box-shadow: var(--shadow);
   color: #ffffff;
-  margin-top: 40px;
+  margin-top: 20px;
   p {
     font-size: 24px;
     font-weight: 700;

--- a/src/components/mypage/WorkerMyPage.jsx
+++ b/src/components/mypage/WorkerMyPage.jsx
@@ -1,0 +1,15 @@
+import MatchingAlarms from './careworker/MatchingAlarms';
+import WorkerProfile from './careworker/WorkderProfile';
+import WorkerButtonBox from './careworker/WorkerButtonBox';
+
+const WorkerMyPage = () => {
+  return (
+    <div>
+      <WorkerProfile />
+      <WorkerButtonBox />
+      <MatchingAlarms />
+    </div>
+  );
+};
+
+export default WorkerMyPage;

--- a/src/components/mypage/careworker/WorkderProfile.jsx
+++ b/src/components/mypage/careworker/WorkderProfile.jsx
@@ -1,6 +1,9 @@
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 const WorkerProfile = () => {
+  const nav = useNavigate();
+
   return (
     <Div>
       <ImgDiv>
@@ -11,7 +14,9 @@ const WorkerProfile = () => {
           <p>김얼리</p>
           <p>요양보호사님</p>
         </div>
-        <button>개인정보 수정하기</button>
+        <button onClick={() => nav(`/editcareworkerinfo/${1}`)}>
+          개인정보 수정하기
+        </button>
       </NameDiv>
     </Div>
   );
@@ -57,7 +62,7 @@ const NameDiv = styled.div`
 
   button {
     width: fit-content;
-    font-size: 14px;
+    font-size: 16px;
     padding: 2px 14px;
     border-radius: 20px;
     background-color: #e5e5e5;

--- a/src/components/mypage/careworker/WorkerButtonBox.jsx
+++ b/src/components/mypage/careworker/WorkerButtonBox.jsx
@@ -33,7 +33,7 @@ const Div = styled.div`
   width: 100%;
   height: 90px;
   border-radius: 20px;
-  background-color: #e5e5e5;
+  background-color: var(--green);
   display: flex;
   align-items: center;
 `;

--- a/src/components/mypage/manager/ManagerButtonBox.jsx
+++ b/src/components/mypage/manager/ManagerButtonBox.jsx
@@ -1,22 +1,26 @@
 import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+
 import chevron from '../../../assets/chevron-right.png';
 
 const ManagerButtonBox = () => {
+  const nav = useNavigate();
+
   return (
     <Div>
-      <div>
+      <div onClick={() => nav('/seniorinfo/register')}>
         <p>어르신 정보 등록하기</p>
         <img src={chevron} />
       </div>
-      <div>
+      <div onClick={() => nav('/list/senior')}>
         <p>어르신 목록 확인하기</p>
         <img src={chevron} />
       </div>
-      <div>
+      <div onClick={() => nav('/seniorinfo/recruit')}>
         <p>구인 정보 등록하기</p>
         <img src={chevron} />
       </div>
-      <div>
+      <div onClick={() => nav('/list/recruit')}>
         <p>구인 공고 목록 확인하기</p>
         <img src={chevron} />
       </div>

--- a/src/components/workercalendar/Calendar.jsx
+++ b/src/components/workercalendar/Calendar.jsx
@@ -49,38 +49,29 @@ const CalendarMain = ({ home }) => {
         }
         navigationLabel={({ date }) => (
           <NavWrapper onClick={(e) => e.stopPropagation()}>
-            <div className="nav">
-              <Select
-                className="month"
-                value={date.getMonth()}
-                onChange={handleMonthChange}
-                disabled={home}
-              >
-                {months.map((month) => (
-                  <option key={month} value={month - 1}>
-                    {month}월
-                  </option>
-                ))}
-              </Select>
-              <Select
-                value={date.getFullYear()}
-                onChange={handleYearChange}
-                disabled={home}
-              >
-                {years.map((year) => (
-                  <option key={year} value={year}>
-                    {year}
-                  </option>
-                ))}
-              </Select>
-            </div>
-            {!home && (
-              <BtnDiv>
-                <div>
-                  <img src={plus} /> 일정 추가하기
-                </div>
-              </BtnDiv>
-            )}
+            <Select
+              className="month"
+              value={date.getMonth()}
+              onChange={handleMonthChange}
+              disabled={home}
+            >
+              {months.map((month) => (
+                <option key={month} value={month - 1}>
+                  {month}월
+                </option>
+              ))}
+            </Select>
+            <Select
+              value={date.getFullYear()}
+              onChange={handleYearChange}
+              disabled={home}
+            >
+              {years.map((year) => (
+                <option key={year} value={year}>
+                  {year}
+                </option>
+              ))}
+            </Select>
           </NavWrapper>
         )}
         next2Label={null}
@@ -116,6 +107,7 @@ const Div = styled.div`
     justify-content: center;
     align-items: center;
     border-radius: 100%;
+    color: #000000;
   }
   .react-calendar__month-view__days__day--weekend {
     color: #000000;
@@ -127,44 +119,46 @@ const Div = styled.div`
   .react-calendar__tile--now {
     background-color: #ffffff;
     &:hover {
-      background-color: var(--green);
+      background-color: var(--blue);
     }
   }
   .react-calendar__tile--active {
     background-color: #ffffff;
     abbr {
-      background-color: #d9d9d9;
+      background-color: var(--blue);
+      box-shadow: var(--shadow);
     }
     &.react-calendar__month-view__days__day--weekend abbr {
-      color: #ffffff;
+      color: #000000;
     }
     &.react-calendar__tile--now abbr {
-      color: #000000; // 임시
+      color: #ffffff;
     }
   }
   .react-calendar__tile,
   .react-calendar__month-view__weekdays__weekday {
     width: 100%;
     max-width: unset;
+    height: 50px !important;
     flex: 1;
     padding: 3px;
     box-sizing: border-box;
     display: flex;
     justify-content: center;
+    align-items: center;
   }
   .react-calendar__tile:focus {
+    background-color: #ffffff;
+  }
+  .react-calendar__tile:hover {
     background-color: #ffffff;
   }
 `;
 
 const NavWrapper = styled.div`
   display: flex;
-  justify-content: space-between;
-  .nav {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-  }
+  flex-direction: column;
+  justify-content: center;
 `;
 
 const Select = styled.select`

--- a/src/components/workercalendar/ScheduleItem.jsx
+++ b/src/components/workercalendar/ScheduleItem.jsx
@@ -4,7 +4,7 @@ const ScheduleItem = ({ time, content, place }) => {
   return (
     <Div>
       <Time>
-        <p>⚫</p>
+        <div className="circle"></div>
         <p>{time}</p>
       </Time>
       <p className="content">{content}</p>
@@ -15,15 +15,15 @@ const ScheduleItem = ({ time, content, place }) => {
 
 const Div = styled.div`
   width: 100%;
-  padding: 20px;
+  padding: 15px 20px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 5px;
   border-radius: 10px;
-  background-color: #d8d8d8;
+  background-color: var(--green);
 
   .content {
-    font-size: 20px;
+    font-size: 24px;
   }
   .place {
     font-size: 14px;
@@ -35,11 +35,14 @@ const Div = styled.div`
 
 const Time = styled.div`
   display: flex;
+  align-items: center;
   gap: 10px;
   font-size: 14px;
-  p:first-child {
-    color: #a9a9a9;
-    opacity: 70%;
+  .circle {
+    width: 14px;
+    height: 14px;
+    border-radius: 100%;
+    background-color: #a9a9a9;
   }
 `;
 

--- a/src/components/workerhistory/HistoryList.jsx
+++ b/src/components/workerhistory/HistoryList.jsx
@@ -50,7 +50,7 @@ const Line = styled.div`
   width: 1px;
   border-right: 1px solid black;
   margin-top: 8px;
-  margin-bottom: 50px;
+  margin-bottom: 70px;
 `;
 
 const ItemListDiv = styled.div`
@@ -61,20 +61,20 @@ const ItemListDiv = styled.div`
 const Item = styled.div`
   width: 100%;
   margin-left: 20px;
-  font-size: 12px;
+  font-size: 16px;
   &:not(:last-child) {
-    margin-bottom: 16px;
+    margin-bottom: 10px;
   }
 
   .name {
-    font-size: 14px;
+    font-size: 24px;
     cursor: pointer;
   }
 `;
 
 const Timeline = styled.div`
   display: flex;
-  gap: 12px;
+  gap: 15px;
   position: relative;
   p:last-child {
     color: var(--blue);

--- a/src/index.css
+++ b/src/index.css
@@ -58,6 +58,7 @@ textarea {
   background-color: transparent;
   border: 0;
   font-family: inherit;
+  color: #000000;
 
   &:focus {
     outline: none;

--- a/src/pages/EditSeniorInfo.jsx
+++ b/src/pages/EditSeniorInfo.jsx
@@ -1,0 +1,150 @@
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+
+import Header from '../components/_common/Header';
+import Title from '../components/_common/Title';
+import Modal from '../components/_common/Modal';
+import RoundButton from '../components/_common/RoundButton';
+import ImgUpload from '../components/registration/ImgUpload';
+import AddressInput from '../components/registration/AddressInput';
+import CaringGrade from '../components/seniorinfo/CaringGrade';
+import Height from '../components/seniorinfo/Height';
+import Weight from '../components/seniorinfo/Weight';
+import Dementia from '../components/seniorinfo/Dementia';
+import EtcDisease from '../components/seniorinfo/EtcDisease';
+import GenderPreference from '../components/seniorinfo/GenderPreference';
+import Cohabitation from '../components/seniorinfo/Cohabitation';
+
+const ModalInfo1 = {
+  type: 'confirm',
+  text: 'ooo 어르신 정보를 삭제하시겠습니까?',
+  btnText1: '아니오',
+  btnText2: '예',
+};
+
+const ModalInfo2 = {
+  type: 'alert',
+  text: '삭제가 완료되었습니다',
+  btnText1: '확인',
+};
+
+const EditSeniorInfo = () => {
+  const nav = useNavigate();
+  const onSave = () => {};
+
+  // 삭제하기 문구 눌렀을 때
+  const onClickDeactivate = () => {
+    setModal1Yn(true);
+  };
+
+  // 삭제하기 모달에서 '예' 눌렀을 때
+  const onDeactivate = () => {
+    setModal2Yn(true);
+  };
+
+  const [modal1Yn, setModal1Yn] = useState(false);
+  const [modal2Yn, setModal2Yn] = useState(false);
+
+  const onClose = () => {
+    setModal1Yn(false);
+    setModal2Yn(false);
+  };
+
+  return (
+    <Container>
+      <Header title="온림 溫林" />
+      <Wrapper>
+        <Title>
+          <p>ㅇㅇㅇ 어르신</p>
+        </Title>
+        <ImgUpload edit />
+        <Div>
+          <FixedWrapper>
+            <Key>이름</Key>
+            <Val>000</Val>
+          </FixedWrapper>
+          <FixedWrapper>
+            <Key>성별</Key>
+            <Val>여성</Val>
+          </FixedWrapper>
+        </Div>
+        <FixedWrapper>
+          <Key>아이디(이메일)</Key>
+          <Val>abc@gmail.com</Val>
+        </FixedWrapper>
+        <FixedWrapper>
+          <Key>생년월일</Key>
+          <Val>1973년 3월 22일</Val>
+        </FixedWrapper>
+        <CaringGrade />
+        <Height />
+        <Weight />
+        <Dementia />
+        <EtcDisease />
+        <GenderPreference />
+        <AddressInput required />
+        <Cohabitation />
+      </Wrapper>
+      <ButtonWrapper>
+        <RoundButton text="취소" mt="40" onClick={() => nav(-1)} />
+        <RoundButton text="저장하기" color="green" onClick={onSave} />
+        <p onClick={onClickDeactivate}>어르신 정보 삭제하기</p>
+      </ButtonWrapper>
+      <Modal
+        isOpen={modal1Yn}
+        onClose={onClose}
+        onClick1={onClose}
+        onClick2={onDeactivate}
+        {...ModalInfo1}
+      />
+      <Modal isOpen={modal2Yn} onClose={onClose} {...ModalInfo2} />
+    </Container>
+  );
+};
+
+export default EditSeniorInfo;
+
+const Container = styled.div`
+  margin-top: 100px;
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;
+
+const Div = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const FixedWrapper = styled.section`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const Key = styled.p`
+  font-size: 16px;
+  margin-right: 30px;
+`;
+
+const Val = styled.p`
+  font-size: 24px;
+  font-weight: bold;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+
+  p {
+    text-decoration: underline;
+    margin-bottom: 30px;
+    cursor: pointer;
+  }
+`;

--- a/src/pages/Menu.jsx
+++ b/src/pages/Menu.jsx
@@ -13,9 +13,11 @@ const Menu = () => {
       <MenuBtnDiv>
         <button onClick={() => nav('/login')}>로그인/회원가입</button>
         <Line />
-        <button onClick={() => nav('/mypage')}>요양보호사 페이지</button>
+        <button onClick={() => nav('/mypage/careworker')}>
+          요양보호사 페이지
+        </button>
         <Line />
-        <button onClick={() => nav('/mypage')}>관리자 페이지</button>
+        <button onClick={() => nav('/mypage/manager')}>관리자 페이지</button>
         <Line />
         <button>FAQ/문의하기</button>
       </MenuBtnDiv>

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -1,41 +1,13 @@
 import styled from 'styled-components';
-import ManagerProfile from '../components/mypage/manager/ManagerProfile';
-import ManagerButtonBox from '../components/mypage/manager/ManagerButtonBox';
-import ManagerMatchingList from '../components/mypage/manager/ManagerMatchingList';
+import { Outlet } from 'react-router-dom';
+
 import Header from '../components/_common/Header';
 
-import chevron from '../assets/chevron-right.png';
-import { useNavigate } from 'react-router-dom';
-import WorkerProfile from '../components/mypage/careworker/WorkderProfile';
-import WorkerButtonBox from '../components/mypage/careworker/WorkerButtonBox';
-import MatchingAlarms from '../components/mypage/careworker/MatchingAlarms';
-
 const MyPage = () => {
-  const nav = useNavigate();
-
-  const type = 'manager'; // 로그인 상태 관리 정보로 변경 예정
-
   return (
     <Div>
       <Header title="내 정보" />
-      {type === 'manager' && (
-        <div>
-          <ManagerProfile />
-          <button className="dashboard" onClick={() => nav('/dashboard')}>
-            <p>대시보드 바로가기</p>
-            <img src={chevron} />
-          </button>
-          <ManagerButtonBox />
-          <ManagerMatchingList />
-        </div>
-      )}
-      {type === 'careworker' && (
-        <div>
-          <WorkerProfile />
-          <WorkerButtonBox />
-          <MatchingAlarms />
-        </div>
-      )}
+      <Outlet />
     </Div>
   );
 };
@@ -47,32 +19,6 @@ const Div = styled.div`
   justify-content: center;
   margin-top: 100px;
   margin-bottom: 30px;
-
-  .dashboard {
-    width: 100%;
-    height: 70px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    position: relative;
-    border-radius: 15px;
-    background-color: var(--blue);
-    box-shadow: var(--shadow);
-    color: #ffffff;
-    margin-top: 40px;
-    p {
-      font-size: 24px;
-      font-weight: 700;
-    }
-    img {
-      -webkit-filter: brightness(0) invert(1);
-      filter: brightness(0) invert(1);
-      width: 24px;
-      height: 24px;
-      position: absolute;
-      right: 20px;
-    }
-  }
 `;
 
 export default MyPage;

--- a/src/pages/WorkerHistory.jsx
+++ b/src/pages/WorkerHistory.jsx
@@ -50,7 +50,7 @@ const BtnDiv = styled.div`
     font-size: 14px;
     padding: 2px 13px;
     border-radius: 20px;
-    background-color: #e2e2e2;
+    background-color: var(--green);
   }
   img {
     width: 14px;

--- a/src/util/ScollToTop.js
+++ b/src/util/ScollToTop.js
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
# 구현 기능

다음과 같은 수정 및 기능 추가를 했습니다.

오류 해결
- 대시보드에서 요양사 상세 정보 보기 모달의 닫기 버튼 클릭이 안 되는 오류
- DetailModal의 자잘한 오류
- img 태그 src='' 오류

기능 및 페이지 추가
- 요양사(/mypage/careworker), 관리자(/mypage/manager) 마이페이지 분리
- 관리자 정보 수정 버튼 추가
- 페이지 이동 시 스크롤이 맨 위로 오는 기능 추가
- 계약 종료 버튼 모달 연결
- 어르신 정보 수정 페이지 퍼블리싱
- 페이지 간 라우팅 연결

디자인 수정
- 컬러링 완료
- index.css에서 기본 텍스트 색 검정으로 설정
- DetailModal, ContractModal 닫기 버튼 img 수정 및 크기 조절

# 구현 상태

![image](https://github.com/user-attachments/assets/fcaec15f-6a04-4116-9add-6faa7c748be6) | ![image](https://github.com/user-attachments/assets/84480c67-b46f-442c-835a-542b788ffe2a) | ![image](https://github.com/user-attachments/assets/7fecb463-6ed4-40c7-9725-57690610338d) | ![image](https://github.com/user-attachments/assets/2165a3a1-ab28-4829-8ba9-6c4c36f91d67) | ![image](https://github.com/user-attachments/assets/a2c1bcba-3ce4-4737-a88f-dfc42c4d8368) | ![image](https://github.com/user-attachments/assets/a85eced3-948e-4262-910d-9cbff8d96cf2)
-----|-----|-----|-----|-----|-----|

# To Reviewers

- 어르신정보수정 페이지 필요 없다면 삭제하셔도 됩니다.
